### PR TITLE
refactor(playground): adopt remote/execute with pull-able schema, seed, and unified views

### DIFF
--- a/collection/CLAUDE.md
+++ b/collection/CLAUDE.md
@@ -1,0 +1,229 @@
+# Collection
+
+CRUD collection abstraction that keeps `pattern` and `remote` generic by providing a dedicated place for client-specific data logic.
+
+## Why This Component Exists
+
+`pattern` matches data. `remote` serves it over HTTP. Neither knows how your data is stored or what rules govern access. **Collection bridges that gap**: it wraps any data source (Datahike, atoms, APIs, files) in a uniform `ILookup + Seqable + Mutable` interface that pattern matching and remote serving consume without coupling to your storage layer.
+
+Without collection, every consumer of pattern/remote would reinvent CRUD wrappers, query validation, serialization, and access control inline. Collection provides the canonical place for all of that.
+
+## Core Design: Protocol + Wrapper + Composition
+
+```
+Your storage (Datahike, atom, API, file...)
+    │
+    ▼
+DataSource protocol ← you implement this (5 methods)
+    │
+    ▼
+Collection type ← uniform ILookup/Seqable/Mutable/Wireable
+    │
+    ├──► read-only wrapper (disables Mutable)
+    ├──► custom wrapper (adds authorization, ownership, etc.)
+    └──► pattern matching / remote serving (consumes ILookup + Mutable)
+```
+
+## How to Support a New Data Source
+
+Implement the `DataSource` protocol — that's all it takes:
+
+```clojure
+(defrecord MySource [conn]
+  coll/DataSource
+  (fetch [_ query] ...)       ;; query is always a map, e.g. {:post/id 3}
+  (list-all [_] ...)          ;; return seq of all items
+  (create! [_ data] ...)      ;; return the created item (with generated ID)
+  (update! [_ query data] ...)  ;; return updated item or nil
+  (delete! [_ query] ...))    ;; return true/false
+
+(def my-coll (coll/collection (->MySource conn)
+                              {:id-key :post/id
+                               :indexes #{#{:post/id}}}))
+```
+
+Then pattern matching works immediately:
+
+```clojure
+(seq my-coll)                    ;; list all
+(get my-coll {:post/id 3})      ;; fetch by indexed query
+(coll/mutate! my-coll nil data) ;; create
+```
+
+### Built-in: atom-source
+
+For in-memory / testing / browser-side use:
+
+```clojure
+(def src (coll/atom-source {:initial [{:id 1 :name "Alice"}]
+                            :id-key :id}))
+(def items (coll/collection src))
+```
+
+`atom-source` also implements `TxSource` for atomic batch mutations via `transact!`/`snapshot`.
+
+## Critical: How Collection Interacts with Pattern and Remote
+
+### Pattern sees ILookup
+
+`pattern` matches against any `ILookup`. When it encounters a map key like `{:post/id 3}`, it calls `(get coll {:post/id 3})`. Collection validates the query against its indexes, then delegates to `DataSource/fetch`. Pattern never calls `mutate!` — it only reads.
+
+### Remote detects mutations and calls mutate!
+
+`remote/http.cljc` parses the incoming pattern to detect mutations:
+
+| Pattern shape | Operation | What remote does |
+|---|---|---|
+| `{:posts '?all}` | Read | Compiles pattern, matches against data |
+| `{:posts {nil {:title "X"}}}` | Create | Calls `(coll/mutate! posts nil {:title "X"})` |
+| `{:posts {{:id 3} {:title "Y"}}}` | Update | Calls `(coll/mutate! posts {:id 3} {:title "Y"})` |
+| `{:posts {{:id 3} nil}}` | Delete | Calls `(coll/mutate! posts {:id 3} nil)` |
+
+Remote checks `(satisfies? coll/Mutable coll)` before mutating. If false (e.g. `read-only` wrapper), it returns an error.
+
+### Wireable for serialization
+
+Remote walks the result tree calling `(coll/->wire x)` on any `Wireable`. Collections serialize to vectors. Custom lookups can serialize to nil (lazy, non-enumerable) or to custom maps.
+
+## Proper Usage Patterns
+
+### 1. One DataSource per storage backend, one Collection per access path
+
+```clojure
+;; CORRECT: single DataSource, multiple Collection wrappers
+(def posts-ds (->PostsDataSource conn))
+(def posts (coll/collection posts-ds {:id-key :post/id}))
+(def public-posts (coll/read-only posts))    ;; guest access
+(def member-posts (->MemberPosts posts uid)) ;; ownership enforcement
+```
+
+### 2. Custom wrappers for authorization logic
+
+Don't put authorization in DataSource. Put it in a wrapper type:
+
+```clojure
+;; CORRECT: wrapper adds access control, DataSource stays generic
+(deftype MemberPosts [posts user-id]
+  ILookup  ;; delegate reads to underlying posts
+  Mutable  ;; check ownership before delegating mutations
+  Wireable ;; delegate serialization)
+```
+
+This keeps DataSource reusable across different access contexts.
+
+### 3. Lazy ILookup for non-enumerable resources
+
+Some resources (history, profile, user-info) can't be listed — only looked up by key. Use `reify` with ILookup + Wireable:
+
+```clojure
+;; CORRECT: lazy lookup that only fetches on access
+(defn history-lookup [conn]
+  (reify
+    clojure.lang.ILookup
+    (valAt [_ query]
+      (when-let [id (:post/id query)]
+        (post-history @conn id)))
+    (valAt [this q nf] (or (.valAt this q) nf))
+
+    coll/Wireable
+    (->wire [_] nil)))  ;; can't enumerate all history, serialize as nil
+```
+
+### 4. Index configuration must match your query patterns
+
+```clojure
+;; If pattern will do: (get coll {:post/author "alice"})
+;; Then collection MUST have that index:
+(coll/collection src {:id-key :post/id
+                      :indexes #{#{:post/id} #{:post/author}}})
+
+;; Without the index, get throws "No index for query"
+```
+
+## Common Mistakes
+
+### Mistake: Recreating collections on every request
+
+```clojure
+;; WRONG: creates new Collection objects every time the API is called
+(defn api-fn [request]
+  {:data {:posts (coll/collection (->PostsDataSource conn))}})
+
+;; Collection + DataSource constructors are cheap, but this prevents
+;; any caching/memoization and confuses the object identity that
+;; wrappers rely on.
+```
+
+```clojure
+;; RIGHT: create collections once, close over them
+(defn make-api [{:keys [conn]}]
+  (let [posts (coll/collection (->PostsDataSource conn) {:id-key :post/id})]
+    (fn [request]
+      {:data {:posts (coll/read-only posts)}})))
+```
+
+**Exception**: wrappers that depend on per-request context (like `MemberPosts` which needs the user-id from the session) must be created per-request. But the underlying collection/DataSource should be stable.
+
+### Mistake: Confusing DataSource and Collection
+
+```clojure
+;; WRONG: passing atom-source directly where Collection is expected
+(def src (coll/atom-source))
+(get src {:id 1})  ;; src is a DataSource, not ILookup!
+
+;; RIGHT: wrap in collection first
+(def items (coll/collection src))
+(get items {:id 1})  ;; Collection implements ILookup
+```
+
+`DataSource` has `fetch/list-all/create!/update!/delete!`.
+`Collection` has `ILookup/Seqable/Counted/Mutable/Wireable`.
+Pattern matching and remote only work with Collection (or any ILookup).
+
+### Mistake: Mutating a read-only collection
+
+```clojure
+;; WRONG: trying to mutate through read-only wrapper
+(def public (coll/read-only posts))
+(coll/mutate! public nil {:title "X"})  ;; throws — Mutable not satisfied
+
+;; RIGHT: use the mutable collection for writes
+(coll/mutate! posts nil {:title "X"})
+```
+
+`read-only` deliberately does NOT implement `Mutable`. Remote checks `(satisfies? coll/Mutable coll)` and returns an error if false.
+
+### Mistake: Returning errors as exceptions from DataSource
+
+```clojure
+;; WRONG in custom wrappers: throwing on business logic errors
+(mutate! [_ query value]
+  (if (owns? query)
+    (coll/mutate! inner query value)
+    (throw (ex-info "Forbidden" {}))))   ;; remote catches this as :execution-error (500)
+
+;; RIGHT: return error as data — remote's :detect picks it up
+(mutate! [_ query value]
+  (if (owns? query)
+    (coll/mutate! inner query value)
+    {:error {:type :forbidden :message "You don't own this post"}}))
+```
+
+Remote's error config uses `:detect :error` to check if the mutation result contains an `:error` key, then maps `:type` to HTTP status codes.
+
+## Protocols Reference
+
+| Protocol | Methods | Purpose |
+|---|---|---|
+| `DataSource` | `fetch`, `list-all`, `create!`, `update!`, `delete!` | Backend storage adapter |
+| `Mutable` | `mutate!` | Unified CRUD: `(nil, data)` = create, `(query, data)` = update, `(query, nil)` = delete |
+| `Wireable` | `->wire` | Serialize for Transit/EDN (collections -> vectors, lazy lookups -> nil) |
+| `TxSource` | `snapshot`, `transact!` | Atomic batch mutations (atom-source only) |
+
+## Testing
+
+```bash
+bb test collection
+```
+
+All tests are inline RCT. When adding new DataSource implementations or wrappers, add RCT tests in the same file covering CRUD, edge cases (empty query, missing index), and Wireable output.

--- a/examples/pull-playground/deps.edn
+++ b/examples/pull-playground/deps.edn
@@ -7,18 +7,17 @@
         ring/ring-core {:mvn/version "1.15.3"}
         com.cognitect/transit-clj {:mvn/version "1.1.347"}
         parinferish/parinferish {:mvn/version "0.8.0"}
-        metosin/malli {:mvn/version "0.20.0"}}
+        metosin/malli {:mvn/version "0.20.0"}
+        no.cjohansen/replicant {:mvn/version "2025.12.1"}}
  :aliases
  {:dev {:extra-paths ["dev"]
         :extra-deps {io.github.robertluo/rich-comment-tests {:mvn/version "1.1.78"}
                      nrepl/nrepl {:mvn/version "1.5.2"}
-                     cider/cider-nrepl {:mvn/version "0.58.0"}
-                     no.cjohansen/replicant {:mvn/version "2025.12.1"}}}
+                     cider/cider-nrepl {:mvn/version "0.58.0"}}}
   :rct {:exec-fn com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree!
         :exec-args {:dirs #{"src"}}}
   :run {:main-opts ["-m" "sg.flybot.playground.server.main"]}
   :cljs {:extra-deps {thheller/shadow-cljs {:mvn/version "3.3.5"}
-                      no.cjohansen/replicant {:mvn/version "2025.12.1"}
                       com.cognitect/transit-cljs {:mvn/version "0.8.280"}
                       org.babashka/sci {:mvn/version "0.12.51"}
                       parinferish/parinferish {:mvn/version "0.8.0"}}}}}

--- a/examples/pull-playground/deps.edn
+++ b/examples/pull-playground/deps.edn
@@ -12,7 +12,8 @@
  {:dev {:extra-paths ["dev"]
         :extra-deps {io.github.robertluo/rich-comment-tests {:mvn/version "1.1.78"}
                      nrepl/nrepl {:mvn/version "1.5.2"}
-                     cider/cider-nrepl {:mvn/version "0.58.0"}}}
+                     cider/cider-nrepl {:mvn/version "0.58.0"}
+                     no.cjohansen/replicant {:mvn/version "2025.12.1"}}}
   :rct {:exec-fn com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree!
         :exec-args {:dirs #{"src"}}}
   :run {:main-opts ["-m" "sg.flybot.playground.server.main"]}

--- a/examples/pull-playground/src/sg/flybot/playground/server/main.clj
+++ b/examples/pull-playground/src/sg/flybot/playground/server/main.clj
@@ -1,6 +1,7 @@
 (ns sg.flybot.playground.server.main
   "Demo server for testing remote mode.
-   Uses standard Remote Pull Protocol v0.2 handler."
+   Uses standard Remote Pull Protocol handler.
+   Schema and reset are pull-able data, not separate endpoints."
   (:require [org.httpkit.server :as http]
             [ring.middleware.params :refer [wrap-params]]
             [sg.flybot.playground.common.data :as data]
@@ -29,6 +30,34 @@
             (assoc-in [:headers "Access-Control-Allow-Origin"] origin))))))
 
 ;;=============================================================================
+;; Sources & Collections
+;;=============================================================================
+
+(defn- make-sources [raw-data]
+  {:users (coll/atom-source {:initial (:users raw-data)})
+   :posts (coll/atom-source {:initial (:posts raw-data)})})
+
+(defn- make-data
+  "Build the data map for api-fn.
+   Includes collections, schema as pull-able data, and reset as a Mutable."
+  [system-atom sources schema sample]
+  (let [colls {:users  (coll/collection (:users sources))
+               :posts  (coll/collection (:posts sources))
+               :config (:config data/default-data)}]
+    (assoc colls
+           :schema {:schema schema :sample sample}
+           :seed  (reify
+                    coll/Mutable
+                    (mutate! [_ _query _value]
+                      (let [new-srcs (make-sources data/default-data)]
+                        (swap! system-atom assoc
+                               :sources new-srcs
+                               :data (make-data system-atom new-srcs schema sample))
+                        true))
+                    coll/Wireable
+                    (->wire [_] nil)))))
+
+;;=============================================================================
 ;; Handlers
 ;;=============================================================================
 
@@ -41,9 +70,11 @@
      :headers {"Content-Type" "text/plain"}
      :body "OK"}))
 
-(defn- make-app [{:keys [data schema sample]}]
+(defn- make-app [{:keys [system-atom schema sample]}]
   (let [api-fn       (fn [_ring-request]
-                       {:data data :schema schema :sample sample})
+                       {:data   (:data @system-atom)
+                        :schema schema
+                        :sample sample})
         pull-handler (remote/make-handler api-fn)]
     (-> (fn [request]
           (or (health-handler request)
@@ -58,17 +89,19 @@
 (defonce system (atom nil))
 
 (defn start! [& [{:keys [port] :or {port 8081}}]]
-  (let [sources {:users (coll/atom-source {:initial (:users data/default-data)})
-                 :posts (coll/atom-source {:initial (:posts data/default-data)})}
-        colls   {:users  (coll/collection (:users sources))
-                 :posts  (coll/collection (:posts sources))
-                 :config (:config data/default-data)}
-        schema  (m/schema data/default-schema)
-        sample  (sample/generate schema {:size 10 :seed 42 :min 5})
-        app     (make-app {:data colls :schema schema :sample sample})
-        stop-fn (http/run-server app {:port port})]
-    (reset! system {:stop-fn stop-fn :data colls :schema schema})
-    (println (str "Server running at http://localhost:" port))))
+  (let [sources    (make-sources data/default-data)
+        schema     (m/schema data/default-schema)
+        api-schema (m/schema (conj data/default-schema
+                                   [:schema {:optional true} :any]
+                                   [:seed {:optional true} :any]))
+        sample     (sample/generate schema {:size 10 :seed 42 :min 5})]
+    (reset! system {:sources sources
+                    :data    (make-data system sources schema sample)
+                    :schema  api-schema})
+    (let [app     (make-app {:system-atom system :schema api-schema :sample sample})
+          stop-fn (http/run-server app {:port port})]
+      (swap! system assoc :stop-fn stop-fn)
+      (println (str "Server running at http://localhost:" port)))))
 
 (defn stop! []
   (when-let [{:keys [stop-fn]} @system]

--- a/examples/pull-playground/src/sg/flybot/playground/ui/core.cljs
+++ b/examples/pull-playground/src/sg/flybot/playground/ui/core.cljs
@@ -122,9 +122,8 @@
      (let [exec (make-executor db)]
        (exec "{:schema ?s}"
              (fn [result]
-               (let [{:keys [schema sample]} (get result 's)]
-                 (dispatch! {:db #(cond-> (state/set-schema % schema)
-                                    sample (assoc :sample-data sample))})))
+               (let [{:keys [schema]} (get result 's)]
+                 (dispatch! {:db #(state/set-schema % schema)})))
              (fn [error]
                (dispatch! {:db #(state/set-schema-error % error)})))))
 

--- a/examples/pull-playground/src/sg/flybot/playground/ui/core/sandbox.cljc
+++ b/examples/pull-playground/src/sg/flybot/playground/ui/core/sandbox.cljc
@@ -1,13 +1,13 @@
 (ns sg.flybot.playground.ui.core.sandbox
   "Sandbox mode — browser-side atom-source collections with CRUD.
 
-   Detects mutations from pattern structure (nil key = create,
-   nil value = delete) and executes patterns against atom-sources."
+   Uses remote/execute directly: same execution engine as the server,
+   but backed by atom-sources instead of a database.
+   Schema and reset are pull-able data in the store, not special endpoints."
   (:require #?(:clj [clojure.edn :as edn]
                :cljs [cljs.reader :as reader])
             [sg.flybot.playground.common.data :as data]
             [sg.flybot.pullable.collection :as coll]
-            [sg.flybot.pullable.impl :as impl]
             [sg.flybot.pullable.remote :as remote]
             [sg.flybot.pullable.malli]
             [malli.core :as m]
@@ -53,52 +53,52 @@
      (sci/eval-form sci-ctx form)))
 
 ;;=============================================================================
-;; Sources
+;; Sources & Collections (held, not ephemeral)
 ;;=============================================================================
 
-(defonce sources (atom nil))
-(defonce compiled-schema (atom nil))
+(defonce ^:private sources* (atom nil))
+(defonce ^:private store* (atom nil))
+(defonce ^:private schema* (atom nil))
 
-(defn- make-sources [data]
-  {:users (coll/atom-source {:initial (:users data)})
-   :posts (coll/atom-source {:initial (:posts data)})})
+(defn- make-sources [raw-data]
+  {:users (coll/atom-source {:initial (:users raw-data)})
+   :posts (coll/atom-source {:initial (:posts raw-data)})})
 
-(defn- make-collections [srcs]
-  {:users (coll/collection (:users srcs))
-   :posts (coll/collection (:posts srcs))})
+(defn- make-store
+  "Build the data map that api-fn returns.
+   Includes collections, schema as pull-able data, and reset as a Mutable."
+  [srcs]
+  {:users   (coll/collection (:users srcs))
+   :posts   (coll/collection (:posts srcs))
+   :config  (:config data/default-data)
+   :schema {:schema data/default-schema}
+   :seed  (reify
+            coll/Mutable
+            (mutate! [_ _query _value]
+              (let [new-srcs (make-sources data/default-data)]
+                (reset! sources* new-srcs)
+                (reset! store* (make-store new-srcs))
+                true))
+            coll/Wireable
+            (->wire [_] nil))})
 
-(defn snapshot []
-  (when-let [srcs @sources]
-    (let [colls (make-collections srcs)]
-      {:users (vec (seq (:users colls)))
-       :posts (vec (seq (:posts colls)))
-       :config (:config data/default-data)})))
+(defn- api-fn
+  "Sandbox api-fn: same contract as server api-fn, backed by atom-sources."
+  [_ctx]
+  {:data   @store*
+   :schema @schema*})
 
 (defn init! []
-  (reset! sources (make-sources data/default-data))
-  (reset! compiled-schema (m/schema data/default-schema))
-  (snapshot))
-
-(defn reset-data! []
-  (init!))
+  (let [srcs (make-sources data/default-data)]
+    (reset! sources* srcs)
+    (reset! store* (make-store srcs))
+    (reset! schema* (m/schema (conj data/default-schema
+                                    [:schema {:optional true} :any]
+                                    [:seed {:optional true} :any])))))
 
 ;;=============================================================================
 ;; Execution
 ;;=============================================================================
-
-(defn- collection? [v]
-  (instance? #?(:clj sg.flybot.pullable.collection.Collection
-                :cljs coll/Collection) v))
-
-(defn- realize
-  "Convert Collection objects to plain vectors."
-  [v]
-  (cond
-    (collection? v) (vec (seq v))
-    (map? v) (into {} (map (fn [[k v]] [k (realize v)])) v)
-    (vector? v) (mapv realize v)
-    (seq? v) (map realize v)
-    :else v))
 
 (defn- read-pattern [s]
   #?(:clj (edn/read-string s)
@@ -106,30 +106,18 @@
 
 (defn execute!
   "Execute a pattern string against sandbox collections.
-   Auto-detects read vs mutation from pattern structure.
-   Returns {:result bindings :snapshot data} or {:error message}."
+   Delegates to remote/execute — same engine the server uses.
+   Returns {:result vars} or {:error message}."
   [pattern-str]
   (try
-    (let [pattern (read-pattern pattern-str)]
-      (if-let [{:keys [path query value]} (remote/parse-mutation pattern)]
-        (let [coll-key (first path)
-              coll (get (make-collections @sources) coll-key)]
-          (if (and coll (satisfies? coll/Mutable coll))
-            {:result {coll-key (coll/mutate! coll query value)}
-             :snapshot (snapshot)}
-            {:error (str "Collection " coll-key " not found or not mutable")}))
-        (let [colls (make-collections @sources)
-              data (assoc colls :config (:config data/default-data))
-              opts #?(:clj  {:schema @compiled-schema}
-                      :cljs {:schema @compiled-schema
-                             :resolve sci-resolve :eval-fn sci-eval})
-              matcher (impl/compile-pattern pattern opts)
-              result (matcher (impl/vmr data))]
-          (if (impl/failure? result)
-            {:error (str "Match failed: " (:reason result)
-                         (when (seq (:path result))
-                           (str " at path " (:path result))))}
-            {:result (realize (:vars result)) :snapshot (snapshot)}))))
+    (let [pattern (read-pattern pattern-str)
+          opts    #?(:clj  {}
+                     :cljs {:resolve sci-resolve :eval-fn sci-eval})
+          result  (remote/execute api-fn pattern opts)]
+      (if (:errors result)
+        (let [{:keys [code reason]} (first (:errors result))]
+          {:error (str (name code) ": " reason)})
+        {:result result}))
     (catch #?(:clj Exception :cljs :default) e
       {:error (str "Error: " #?(:clj (.getMessage e) :cljs (.-message e)))})))
 
@@ -145,7 +133,13 @@
   (do (init!) (get-in (execute! "{:users ?all}") [:result 'all]))
   ;=>> vector?
 
+  ;; schema is pull-able
+  (do (init!) (get-in (execute! "{:schema ?s}") [:result 's :schema]))
+  ;=>> vector?
+
+  ;; seed via mutation restores initial data
   (do (init!)
-      (-> (execute! "{:users {nil {:id 99 :name \"Dave\" :email \"d@e\" :role :user}}}")
-          :snapshot :users count)))
-  ;=> 4)
+      (execute! "{:users {nil {:id 99 :name \"Dave\" :email \"d@e\" :role :user}}}")
+      (execute! "{:seed {nil true}}")
+      (-> (execute! "{:users ?all}") :result (get 'all) count)))
+  ;=> 3)

--- a/examples/pull-playground/src/sg/flybot/playground/ui/core/state.cljc
+++ b/examples/pull-playground/src/sg/flybot/playground/ui/core/state.cljc
@@ -21,10 +21,7 @@
    :data-view :data        ; :data | :schema toggle
    ;; Remote mode config
    :server-url "http://localhost:8081/api"
-   :schema-loading? false
    :schema-error nil
-   :sample-data nil        ; Generated sample data from schema
-   :schema-view-mode :schema ; :schema | :sample toggle
    ;; Autocomplete
    :autocomplete nil})     ; {:completions [...] :selected 0 :prefix ":" :x :y}
 
@@ -42,8 +39,7 @@
   (-> db
       (assoc :mode mode)
       (assoc :result nil :error nil :selected-example nil)
-      (assoc :data nil :schema nil :schema-error nil :sample-data nil)
-      (assoc :schema-view-mode :schema)))
+      (assoc :data nil :schema nil :schema-error nil)))
 
 (defn set-result [db result]
   (assoc db :loading? false :result result :error nil))
@@ -59,10 +55,10 @@
 ;;=============================================================================
 
 (defn set-schema [db schema]
-  (assoc db :schema-loading? false :schema schema :schema-error nil :sample-data nil))
+  (assoc db :schema schema :schema-error nil))
 
 (defn set-schema-error [db error]
-  (assoc db :schema-loading? false :schema nil :schema-error error :sample-data nil))
+  (assoc db :schema nil :schema-error error))
 
 ;;=============================================================================
 ;; Autocomplete updaters
@@ -118,10 +114,10 @@
     (:data db))
   ;=> {:users [{:id 1}]}
 
-  ;; set-schema stores schema and clears sample-data
-  (let [db (set-schema {:schema-loading? true :sample-data {:old "data"}} [:map [:name :string]])]
-    [(:schema-loading? db) (:schema db) (:sample-data db)])
-  ;=> [false [:map [:name :string]] nil]
+  ;; set-schema stores schema and clears error
+  (let [db (set-schema {:schema-error "old"} [:map [:name :string]])]
+    [(:schema db) (:schema-error db)])
+  ;=> [[:map [:name :string]] nil]
 
   ;; move-autocomplete-selection wraps around
   (let [db {:autocomplete {:completions [:a :b :c] :selected 2}}]

--- a/examples/pull-playground/src/sg/flybot/playground/ui/core/views.cljc
+++ b/examples/pull-playground/src/sg/flybot/playground/ui/core/views.cljc
@@ -6,8 +6,8 @@
             [sg.flybot.playground.ui.core.views.edn-editor-interactive.editor :as edn]
             [sg.flybot.playground.ui.core.state :as state]
             [clojure.string :as str]
-            #?(:cljs [sg.flybot.playground.ui.core.views.edn-editor-interactive :as edn-i])
-            #?(:cljs [replicant.alias :refer [defalias]])))
+            [replicant.alias :refer [defalias]]
+            #?(:cljs [sg.flybot.playground.ui.core.views.edn-editor-interactive :as edn-i])))
 
 ;;=============================================================================
 ;; Helpers
@@ -43,33 +43,28 @@
 ;; Components
 ;;=============================================================================
 
-#?(:cljs
-   (defalias site-header
-     [{::keys [db dispatch!]}]
-     (let [{:keys [mode]} db]
-       [:header.site-header
-        [:h1 "Pull Pattern Playground"]
-        [:div.header-right
-         [:div.mode-toggle
-          [:button {:class (when (= mode :sandbox) "active")
-                    :on {:click #(dispatch! {:db   (fn [db] (state/set-mode db :sandbox))
-                                             :nav  :sandbox
-                                             :pull :init})}}
-           "Sandbox"]
-          [:button {:class (when (= mode :remote) "active")
-                    :on {:click #(dispatch! {:db   (fn [db] (state/set-mode db :remote))
-                                             :nav  :remote
-                                             :pull :init})}}
-           "Remote"]]
+(defalias site-header
+  [{::keys [db dispatch!]}]
+  (let [{:keys [mode]} db]
+    [:header.site-header
+     [:h1 "Pull Pattern Playground"]
+     [:div.header-right
+      [:div.mode-toggle
+       [:button {:class (when (= mode :sandbox) "active")
+                 :on {:click #(dispatch! {:db   (fn [db] (state/set-mode db :sandbox))
+                                          :nav  :sandbox
+                                          :pull :init})}}
+        "Sandbox"]
+       [:button {:class (when (= mode :remote) "active")
+                 :on {:click #(dispatch! {:db   (fn [db] (state/set-mode db :remote))
+                                          :nav  :remote
+                                          :pull :init})}}
+        "Remote"]]
+      #?(:cljs
          [:button.theme-toggle {:title "Toggle theme"
                                 :on {:click #(js/sg.flybot.playground.ui.core.toggle_theme_BANG_)}}
           [:span.show-light (moon-icon)]
-          [:span.show-dark (sun-icon)]]]])))
-
-#?(:clj
-   (defn site-header [{}]
-     [:header.site-header
-      [:h1 "Pull Pattern Playground"]]))
+          [:span.show-dark (sun-icon)]])]]))
 
 ;;-----------------------------------------------------------------------------
 ;; Data Panel
@@ -93,36 +88,27 @@
     (let [text (format-result-pretty (if (= data-view :schema) displayed-schema displayed-data))]
       (edn/edn-display {:value text :placeholder "No data"}))]])
 
-#?(:cljs
-   (defalias data-panel
-     [{::keys [db dispatch!]}]
-     (let [{:keys [mode server-url data schema data-view]} db]
-       [:div.panel.data-panel
-        [:div.panel-header
-         [:h2 "Data"]]
-        [:div.panel-content
-         (when (= mode :remote)
-           [:div.remote-sections
-            [:div.editor-section.url-section
-             [:label "Server URL"
-              [:span.info-hint {:data-tooltip "Remote mode connects to a running Pull Pattern server. Clone the repository and run the demo server locally."} "i"]]
-             [:input {:type "text"
-                      :value server-url
-                      :placeholder "http://localhost:8081/api"
-                      :on {:input #(dispatch! {:db (fn [db] (assoc db :server-url (.. % -target -value)))})}}]]])
-         (data-display
-          {::displayed-data data
-           ::displayed-schema schema
-           ::data-view data-view
-           ::dispatch! dispatch!})]]))
-
-   :clj
-   (defn data-panel [{}]
-     [:div.panel.data-panel
-      [:div.panel-header
-       [:h2 "Data"]]
-      [:div.panel-content
-       [:div "Sample data"]]]))
+(defalias data-panel
+  [{::keys [db dispatch!]}]
+  (let [{:keys [mode server-url data schema data-view]} db]
+    [:div.panel.data-panel
+     [:div.panel-header
+      [:h2 "Data"]]
+     [:div.panel-content
+      (when (= mode :remote)
+        [:div.remote-sections
+         [:div.editor-section.url-section
+          [:label "Server URL"
+           [:span.info-hint {:data-tooltip "Remote mode connects to a running Pull Pattern server. Clone the repository and run the demo server locally."} "i"]]
+          [:input {:type "text"
+                   :value server-url
+                   :placeholder "http://localhost:8081/api"
+                   :on {:input #(dispatch! {:db (fn [db] (assoc db :server-url (.. % -target -value)))})}}]]])
+      (data-display
+       {::displayed-data data
+        ::displayed-schema schema
+        ::data-view data-view
+        ::dispatch! dispatch!})]]))
 
 ;;-----------------------------------------------------------------------------
 ;; Pattern + Results Panel
@@ -130,21 +116,20 @@
 
 (def ^:private pattern-editor-id "pattern-editor")
 
-#?(:cljs
-   (defalias pattern-results-panel
-     [{::keys [db dispatch!]}]
-     (let [{:keys [pattern-text loading? schema autocomplete result error]} db]
-       [:div.panel.pattern-results-panel
-        ;; Pattern section
-        [:div.pattern-section
-         [:div.section-header
-          [:label "Pattern"]
-          [:button.execute-btn
-           {:on {:click #(dispatch! {:db state/set-loading
-                                     :pull (:pattern-text db)})}
-            :disabled loading?}
-           (if loading? "Executing..." "Execute")]]
-         [:div.pattern-editor
+(defalias pattern-results-panel
+  [{::keys [db dispatch!]}]
+  (let [{:keys [pattern-text loading? schema autocomplete result error]} db]
+    [:div.panel.pattern-results-panel
+     [:div.pattern-section
+      [:div.section-header
+       [:label "Pattern"]
+       [:button.execute-btn
+        {:on {:click #(dispatch! {:db state/set-loading
+                                  :pull (:pattern-text db)})}
+         :disabled loading?}
+        (if loading? "Executing..." "Execute")]]
+      [:div.pattern-editor
+       #?(:cljs
           (edn-i/edn-editor
            {:value pattern-text
             :placeholder "Enter a pull pattern, e.g. {:name ?n}"
@@ -157,93 +142,65 @@
             :on-autocomplete #(dispatch! {:db (fn [db] (state/show-autocomplete db %))})
             :on-autocomplete-hide #(dispatch! {:db state/hide-autocomplete})
             :on-autocomplete-select #(dispatch! {:db (fn [db] (state/select-autocomplete db %))})
-            :on-autocomplete-move #(dispatch! {:db (fn [db] (state/move-autocomplete-selection db %))})})]
+            :on-autocomplete-move #(dispatch! {:db (fn [db] (state/move-autocomplete-selection db %))})})
+          :clj
+          [:textarea {:value pattern-text
+                      :placeholder "Enter a pull pattern, e.g. {:name ?n}"}])]
+      #?(:cljs
          (when autocomplete
            (edn-i/editor-autocomplete
             {:editor-id pattern-editor-id
              :autocomplete autocomplete
              :on-change #(dispatch! {:db (fn [db] (assoc db :pattern-text %))})
              :on-autocomplete-hide #(dispatch! {:db state/hide-autocomplete})
-             :on-autocomplete-select #(dispatch! {:db (fn [db] (state/select-autocomplete db %))})}))]
-        ;; Results section
-        [:div.results-section
-         [:div.section-header
-          [:label "Results"]]
-         [:div.results-content
-          (cond
-            loading?
-            [:div.loading "Executing pattern..."]
+             :on-autocomplete-select #(dispatch! {:db (fn [db] (state/select-autocomplete db %))})})))]
+     [:div.results-section
+      [:div.section-header
+       [:label "Results"]]
+      [:div.results-content
+       (cond
+         loading?
+         [:div.loading "Executing pattern..."]
 
-            error
-            [:div.result-value.error error]
+         error
+         [:div.result-value.error error]
 
-            result
-            [:div.result-value.success
-             (edn/highlight-edn (format-result-pretty result))]
+         result
+         [:div.result-value.success
+          (edn/highlight-edn (format-result-pretty result))]
 
-            :else
-            [:div.result-value.empty "Enter a pattern and data, then click Execute"])]]]))
-
-   :clj
-   (defn pattern-results-panel [{::keys [db dispatch!]}]
-     (let [{:keys [pattern-text result error]} db]
-       [:div.panel.pattern-results-panel
-        [:div.pattern-section
-         [:div.section-header
-          [:label "Pattern"]
-          [:button.execute-btn "Execute"]]
-         [:div.pattern-editor
-          [:textarea {:value pattern-text
-                      :placeholder "Enter a pull pattern, e.g. {:name ?n}"}]]]
-        [:div.results-section
-         [:div.section-header [:label "Results"]]
-         [:div.results-content
-          (cond
-            error [:div.result-value.error error]
-            result [:div.result-value.success (format-result-pretty result)]
-            :else [:div.result-value.empty "Enter a pattern and data, then click Execute"])]]])))
+         :else
+         [:div.result-value.empty "Enter a pattern and data, then click Execute"])]]]))
 
 ;;-----------------------------------------------------------------------------
 ;; Examples Panel
 ;;-----------------------------------------------------------------------------
 
-#?(:cljs
-   (defalias examples-panel
-     [{::keys [selected-example dispatch!]}]
-     [:div.panel.examples-panel
-      [:div.panel-header
-       [:h2 "Examples"]]
-      [:div.panel-content
-       [:ul.example-list
-        (for [[idx example] (map-indexed vector examples/examples)]
-          [:li {:replicant/key idx
-                :class (when (= idx selected-example) "active")
-                :title (:description example)
-                :on {:click #(dispatch!
-                              {:db (fn [db]
-                                     (-> db
-                                         (assoc :pattern-text (:pattern example)
-                                                :selected-example idx)
-                                         state/clear-result))})}}
-           (:name example)])]
-       [:div.syntax-reference
-        [:h3 "Syntax Reference"]
-        [:div.syntax-list
-         (for [{:keys [syntax description]} examples/syntax-reference]
-           [:div.syntax-item {:replicant/key syntax}
-            [:code syntax]
-            [:span description]])]]]])
-
-   :clj
-   (defn examples-panel [{::keys [selected-example dispatch!]}]
-     [:div.panel.examples-panel
-      [:div.panel-header [:h2 "Examples"]]
-      [:div.panel-content
-       [:ul.example-list
-        (for [[idx example] (map-indexed vector examples/examples)]
-          [:li {:replicant/key idx
-                :class (when (= idx selected-example) "active")}
-           (:name example)])]]]))
+(defalias examples-panel
+  [{::keys [selected-example dispatch!]}]
+  [:div.panel.examples-panel
+   [:div.panel-header
+    [:h2 "Examples"]]
+   [:div.panel-content
+    [:ul.example-list
+     (for [[idx example] (map-indexed vector examples/examples)]
+       [:li {:replicant/key idx
+             :class (when (= idx selected-example) "active")
+             :title (:description example)
+             :on {:click #(dispatch!
+                           {:db (fn [db]
+                                  (-> db
+                                      (assoc :pattern-text (:pattern example)
+                                             :selected-example idx)
+                                      state/clear-result))})}}
+        (:name example)])]
+    [:div.syntax-reference
+     [:h3 "Syntax Reference"]
+     [:div.syntax-list
+      (for [{:keys [syntax description]} examples/syntax-reference]
+        [:div.syntax-item {:replicant/key syntax}
+         [:code syntax]
+         [:span description]])]]]])
 
 ;;=============================================================================
 ;; App Root
@@ -252,17 +209,12 @@
 (defn app-view [{::keys [db dispatch!]}]
   (let [{:keys [selected-example]} db]
     [:div.app-container
-     #?(:cljs [::site-header {::db db ::dispatch! dispatch!}]
-        :clj  (site-header {::db db ::dispatch! dispatch!}))
+     [::site-header {::db db ::dispatch! dispatch!}]
      [:div.main-content.with-sidebar
-      #?(:cljs [::data-panel {::db db ::dispatch! dispatch!}]
-         :clj  (data-panel {::db db ::dispatch! dispatch!}))
-      #?(:cljs [::pattern-results-panel {::db db ::dispatch! dispatch!}]
-         :clj  (pattern-results-panel {::db db ::dispatch! dispatch!}))
-      #?(:cljs [::examples-panel {::selected-example selected-example
-                                  ::dispatch! dispatch!}]
-         :clj  (examples-panel {::selected-example selected-example
-                                ::dispatch! dispatch!}))]]))
+      [::data-panel {::db db ::dispatch! dispatch!}]
+      [::pattern-results-panel {::db db ::dispatch! dispatch!}]
+      [::examples-panel {::selected-example selected-example
+                         ::dispatch! dispatch!}]]]))
 
 ;;=============================================================================
 ;; Tests

--- a/remote/src/sg/flybot/pullable/remote.cljc
+++ b/remote/src/sg/flybot/pullable/remote.cljc
@@ -109,6 +109,28 @@
    Read patterns (keyword query keys or ?-variable values) return nil."
   http/parse-mutation)
 
+(def execute
+  "Execute a pull pattern directly (no HTTP). Used by in-process callers
+   like browser sandboxes that share the same execution engine as the server.
+
+   api-fn:  (fn [context] {:data ... :schema ... :errors ...})
+   pattern: Clojure data structure (EDN)
+   opts:    {:params  {...}  ; $-param substitution
+             :resolve fn     ; symbol resolver (default: safe whitelist)
+             :eval-fn fn     ; form evaluator (default: blocked)
+             :context map}   ; passed to api-fn
+
+   Returns vars map on success, {:errors [...]} on failure.
+
+   ```clojure
+   (def api-fn
+     (fn [_ctx] {:data {:posts posts-coll}}))
+
+   (execute api-fn '{:posts ?all})
+   ;; => {'all [...]}
+   ```"
+  http/execute)
+
 ;; For client implementations
 (def encode
   "Encode Clojure data to bytes. Format: :transit-json, :transit-msgpack, :edn."
@@ -123,6 +145,7 @@
   make-handler ;=>> fn?
   wrap-api ;=>> fn?
   parse-mutation ;=>> fn?
+  execute ;=>> fn?
   encode ;=>> fn?
   decode ;=>> fn?
   )


### PR DESCRIPTION
## remote
- Add public `execute` fn for transport-agnostic pattern execution (no HTTP needed)
- `execute-pull` kept as thin wrapper delegating to `execute` for backward compatibility
- Re-export `execute` from `sg.flybot.pullable.remote` public API

## pull-playground
- Sandbox delegates to `remote/execute` instead of hand-rolling pattern compilation
- Schema and seed are now pull-able data in the store (`{:schema ?s}`, `{:seed {nil true}}`)
- Collapse sandbox-api/remote-api into single flat `pull-api` with `make-executor` as only mode-specific fn
- Unify all `defalias` components as `.cljc` — reader conditionals only inside for JS-specific parts
- Uniform `[::alias-name props]` syntax in `app-view`, no platform split
- Remove dead state keys (`schema-loading?`, `sample-data`, `schema-view-mode`)
- Add Replicant to `:dev` deps for CLJ test classpath